### PR TITLE
move element definition to in-file

### DIFF
--- a/src/ia-sharing-options.js
+++ b/src/ia-sharing-options.js
@@ -134,3 +134,5 @@ export class IASharingOptions extends LitElement {
     `;
   }
 }
+
+customElements.define('ia-sharing-options', IASharingOptions);

--- a/test/ia-sharing-options.test.js
+++ b/test/ia-sharing-options.test.js
@@ -1,8 +1,6 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import sinon from 'sinon';
-import { IASharingOptions } from '../src/ia-sharing-options.js';
-
-customElements.define('ia-sharing-options', IASharingOptions);
+import '../src/ia-sharing-options.js';
 
 const identifier = 'goody';
 const itemType = 'book';


### PR DESCRIPTION
part of work to generalize & reduce `*-navigator` cognitive load.